### PR TITLE
Add short description in instance list

### DIFF
--- a/translations/en.json
+++ b/translations/en.json
@@ -67,7 +67,7 @@
   "contributers": "Contributors",
   "thanks_translators": "A special thanks to our translators: ",
   "thanks_coders": "A special thanks to our coders: ",
-  "instance_totals": "The lemmyverse currently has {{instances}} instances, and {{users}} monthly active users.",
+  "instance_totals": "You can access all content in the lemmyverse from any server/instance. The lemmyverse currently has {{instances}} instances, and {{users}} monthly active users.",
   "news": "News",
   "releases": "Lemmy Releases",
   "add_weblate": "You can add translations via our <1>weblate</1>.",

--- a/translations/es.json
+++ b/translations/es.json
@@ -64,7 +64,7 @@
   "contributers": "Contribuyentes",
   "thanks_translators": "Un agradecimiento especial a nuestros traductores: ",
   "thanks_coders": "Un agradecimiento especial a nuestros programadores: ",
-  "instance_totals": "El lemmyverso tiene actualmente {{instances}} instancias y {{users}} usuarios mensualmente activos.",
+  "instance_totals": "Puedes acceder a todo el contenido del lemmyverso desde cualquier servidor/instancia. El lemmyverso tiene actualmente {{instances}} instancias y {{users}} usuarios mensualmente activos.",
   "users": "usuarios",
   "month": "mes",
   "about_title": "Acerca de Lemmy",

--- a/translations/eu.json
+++ b/translations/eu.json
@@ -57,7 +57,7 @@
   "rss_feeds": "RSS/Atom iturriak <1>Guztiak</1>, <2>Harpidetuak</2>, <3>Postontzia</3>, <4>Erabiltzailea</4>, eta <5>Komunitatea</5>.",
   "api_libraries": "API liburutegiak",
   "donate_desc": "Lemmy software librea eta kode irekia da, eta horrek esan nahi du ez dagoela publizitaterik, monetizaziorik edo arrisku-kapitalik, inoiz ez. <1>Zure dohaintzek</1> zuzenean babesten dute proiektuaren lanaldi osoko garapena.",
-  "instance_totals": "Lemmybertsoak orain {{instances}} instantzia eta {{users}} erabiltzaile ditu.",
+  "instance_totals": "Lemmybertso osoa izango duzu eskura edozein zerbitzari/instantzia hautatzen duzula ere. Lemmybertsoak orain {{instances}} instantzia eta {{users}} erabiltzaile ditu.",
   "support": "Euskarria",
   "support_title": "Lemmy - Euskarria",
   "support_lemmy": "Lagundu Lemmyri",


### PR DESCRIPTION
The goal of this is to make sure new users are aware of federation before choosing an instance, hopefully mitigating issues like the overcrowding of [lemmy.ml](https://lemmy.ml/). It implements the strategy described in issue https://github.com/LemmyNet/joinlemmy-site/issues/155, which it should close.

The explanation consists on a single sentence before instance statistics in the instance selection page. This sentence is worded so that the following are made somewhat clearer:

* Users of any instance have access to content in all other instances.
* "Instance" and "server" refer to the same thing.
* "Lemmyverse" refers to the set of all instances.

I've added equivalent explanation in the three languages that I can best handle, namely English, Spanish and Basque. The specific translations have been chosen as follows:

:gb: **You can access all content in the lemmyverse from any server/instance.**

_Accessing_ implies further abilities beyond just _seeing_ or _exploring_, and _all content_, as opposed to any other wording, further assures that nothing is lost from choosing one server over another. I used "you" to better associate the new information with the choice at hand.

:es: **Puedes acceder a todo el contenido del lemmyverso desde cualquier servidor/instancia.**

Fundamentally the same as the English version. _Puedes acceder a todo el contenido_ and similar phrases are also a common formula for commercial services in Spanish.

:red_circle: :green_circle: :white_circle: **Lemmybertso osoa izango duzu eskura edozein zerbitzari/instantzia hautatzen duzula ere.**

I tried to prioritize a "native" sounding sentence here. It translates to "You'll have the whole lemmyverse within reach no matter what server/instance you choose".

I've tested it locally by following the instructions at [LemmyNet/joinlemmy-site](https://github.com/LemmyNet/joinlemmy-site). Huge thanks to @Nutomic for his guidance; I'd probably have spent days figuring this out on my own.